### PR TITLE
feat: fix booking flow, wallet page and checkout modal

### DIFF
--- a/app/(protected)/orders/page.tsx
+++ b/app/(protected)/orders/page.tsx
@@ -349,6 +349,7 @@ export default function OrdersPage() {
         (order) =>
           (order.status === "accepted" ||
             order.status === "ongoing" ||
+            order.status === "ready_for_pickup" ||
             order.status === "in_progress") &&
           !!order.riderId
       );
@@ -545,7 +546,16 @@ export default function OrdersPage() {
                   <p className="text-sm font-semibold uppercase tracking-wide text-white/70">
                     Order Details
                   </p>
-                  <p className="mt-1 text-xs text-white/60">Thu, 30th Nov, 2025</p>
+                  <p className="mt-1 text-xs text-white/60">
+                    {selectedOrder.createdAt
+                      ? new Date(selectedOrder.createdAt).toLocaleDateString("en-GB", {
+                          weekday: "short",
+                          day: "numeric",
+                          month: "short",
+                          year: "numeric",
+                        })
+                      : ""}
+                  </p>
                 </div>
                 <button
                   className="text-white/60 hover:text-white"

--- a/app/(protected)/profile/page.tsx
+++ b/app/(protected)/profile/page.tsx
@@ -2,21 +2,22 @@
 
 import ProviderProfilePage from "@/components/dashboard/pages/ProfilePage";
 import ClientProfilePage from "@/components/dashboard/pages/ClientProfilePage";
-import { useAuth, useEnrichedProfile } from "@/lib/hooks";
+import { useAuth } from "@/lib/hooks";
 
 export default function Profile() {
+  // Route based ONLY on the authenticated user's own userType from auth state.
+  // Never rely on a fetched profile's userType — the profile fetch can return
+  // stale or wrong data if the uid in Redux is incorrect.
   const { user, isDiva, isHunk, isClient } = useAuth();
-  const { profile } = useEnrichedProfile(user?.id || null);
 
-  const userType = profile?.user?.userType || user?.userType;
-
-  if (isClient || userType === "client") {
+  if (isClient || user?.userType === "client") {
     return <ClientProfilePage />;
   }
 
-  if (isDiva || isHunk || userType === "diva" || userType === "hunk") {
+  if (isDiva || isHunk || user?.userType === "diva" || user?.userType === "hunk") {
     return <ProviderProfilePage />;
   }
 
+  // Fallback: show client page (safer default — provider page needs provider profile)
   return <ClientProfilePage />;
 }

--- a/app/(protected)/wallet/page.tsx
+++ b/app/(protected)/wallet/page.tsx
@@ -1,288 +1,281 @@
 "use client";
 
-import { useState, useEffect } from "react";
-import { Wallet, Plus, Download, ArrowDownLeft, ArrowUpRight, CheckCircle2, XCircle, Clock, X, ArrowUp, ChevronDown, AlertCircle, CheckCircle, HandCoins, Eye, EyeOff } from "lucide-react";
-import { useGetWalletBalanceQuery, useGetTransactionsQuery, useFundWalletMutation, useVerifyPaymentMutation } from "@/app/api/apiSlice";
+import { useState, useEffect, useMemo } from "react";
+import { Wallet, Plus, Download, ArrowDownLeft, ArrowUpRight, X, ChevronDown, AlertCircle, CheckCircle, HandCoins, Eye, EyeOff } from "lucide-react";
+import {
+  useGetWalletBalanceQuery,
+  useGetTransactionsQuery,
+  useFundWalletMutation,
+  useVerifyPaymentMutation,
+  useCreatePayoutMutation,
+  useGetWithdrawalAccountsQuery,
+} from "@/app/api/apiSlice";
 import { useAuth, useAuthProfile } from "@/lib/hooks";
-import { useMemo } from "react";
+
 export default function WalletPage() {
   const { user } = useAuthProfile();
   const { isDiva, isHunk } = useAuth();
+
   const { data: walletBalanceData, isLoading: isLoadingBalance, refetch: refetchBalance } = useGetWalletBalanceQuery(undefined, {
-    pollingInterval: 30000, // Poll every 30 seconds
+    pollingInterval: 30000,
     refetchOnMountOrArgChange: true,
   });
   const { data: transactionsData, isLoading: isLoadingTransactions, refetch: refetchTransactions } = useGetTransactionsQuery({ limit: 50 }, {
-    pollingInterval: 30000, // Poll every 30 seconds
+    pollingInterval: 30000,
     refetchOnMountOrArgChange: true,
   });
+
   const [fundWallet, { isLoading: isFundingWallet }] = useFundWalletMutation();
   const [verifyPayment, { isLoading: isVerifyingPayment }] = useVerifyPaymentMutation();
-  
+  const [createPayout, { isLoading: isRequestingPayout }] = useCreatePayoutMutation();
+
+  const { data: accountsData } = useGetWithdrawalAccountsQuery(undefined, { skip: !(isDiva || isHunk) });
+  const withdrawalAccounts = useMemo(() => {
+    const d = accountsData?.data;
+    return Array.isArray(d) ? d : [];
+  }, [accountsData]);
+
+  // Fund wallet state
   const [isFundModalOpen, setIsFundModalOpen] = useState(false);
-  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
   const [fundAmount, setFundAmount] = useState("");
-  const [currency, setCurrency] = useState("NGN");
+  const [fundError, setFundError] = useState<string | null>(null);
+  const [currency] = useState("NGN");
+
+  // Payout state
+  const [isPayoutModalOpen, setIsPayoutModalOpen] = useState(false);
+  const [payoutAmount, setPayoutAmount] = useState("");
+  const [selectedAccountId, setSelectedAccountId] = useState("");
+  const [payoutError, setPayoutError] = useState<string | null>(null);
+  const [payoutSuccess, setPayoutSuccess] = useState<{ amount: number; netAmount: number } | null>(null);
+
+  // Success/verify state
+  const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
   const [fundedAmount, setFundedAmount] = useState(0);
-  const [paymentReference, setPaymentReference] = useState<string | null>(null);
+  const [verifyError, setVerifyError] = useState<string | null>(null);
+  // Optimistic balance — set immediately from verify response, overrides query data until next refetch
+  const [optimisticBalance, setOptimisticBalance] = useState<number | null>(null);
+
   const [isBalanceVisible, setIsBalanceVisible] = useState(true);
-  
+
   const walletBalance = useMemo(() => {
-    if (walletBalanceData?.success && walletBalanceData?.data) {
-      return walletBalanceData.data;
-    }
+    if (walletBalanceData?.success && walletBalanceData?.data) return walletBalanceData.data;
     return null;
   }, [walletBalanceData]);
 
+  // Use optimistic balance if set (from verify response), otherwise fall back to query data
+  const displayBalance = optimisticBalance ?? walletBalance?.balance ?? 0;
+
   const transactions = useMemo(() => {
-    if (transactionsData?.success && transactionsData?.data && Array.isArray(transactionsData.data) && transactionsData.data.length > 0) {
-      return transactionsData.data;
-    }
+    if (transactionsData?.success && Array.isArray(transactionsData.data)) return transactionsData.data;
     return [];
   }, [transactionsData]);
 
-  // Calculate APH equivalent (1 APH = 1.25 NGN)
-  const calculateAPH = (ngnAmount: number) => {
-    return ngnAmount / 1.25;
-  };
-
-  // Calculate what user will get after 5% fee
-  const calculateAfterFee = (aphAmount: number) => {
-    return aphAmount * 0.95; // 5% fee deducted
-  };
-
-  const handleVerifyPayment = async (reference: string) => {
-    try {
-      const result = await verifyPayment({ reference }).unwrap();
-      if (result.success && result.data) {
-        setFundedAmount(result.data.amount);
-        setPaymentReference(reference);
-        setIsSuccessModalOpen(true);
-        // Refetch balance and transactions
-        refetchBalance();
-        refetchTransactions();
-        // Clear URL parameters
-        if (typeof window !== 'undefined') {
-          window.history.replaceState({}, '', '/wallet');
-        }
-      }
-    } catch (error) {
-      console.error("Payment verification failed:", error);
-      alert("Payment verification failed. Please contact support.");
-    }
-  };
-
-  // Handle payment verification from Paystack callback
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    
-    const urlParams = new URLSearchParams(window.location.search);
-    const reference = urlParams.get('reference');
-    const trxref = urlParams.get('trxref');
-    const paymentRef = reference || trxref;
-    
-    console.log('Payment verification check:', { reference, trxref, paymentRef, isSuccessModalOpen, isVerifyingPayment });
-    
-    if (paymentRef && !isSuccessModalOpen && !isVerifyingPayment) {
-      console.log('Initiating payment verification for reference:', paymentRef);
-      handleVerifyPayment(paymentRef);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  const handleFundWallet = async () => {
-    if (!fundAmount || parseFloat(fundAmount) <= 0) {
-      alert("Please enter a valid amount");
-      return;
-    }
-
-    if (!user?.email) {
-      alert("User email is required for payment");
-      return;
-    }
-
-    try {
-      const ngnAmount = parseFloat(fundAmount);
-      const aphEquivalent = calculateAPH(ngnAmount);
-      const aphAfterFee = calculateAfterFee(aphEquivalent);
-      
-      // Validate minimum funding amount (100 APH = ₦125)
-      if (aphEquivalent < 100) {
-        alert(`Minimum funding amount is 100 APH (₦${(100 * 1.25).toFixed(2)}). Please enter a higher amount.`);
-        return;
-      }
-      
-      // Send the FULL amount (before fee) to the backend
-      // Backend will handle the 5% fee deduction and credit the after-fee amount
-      const result = await fundWallet({
-        amount: aphEquivalent, // Send full amount, backend will deduct fee
-        email: user.email,
-        callbackUrl: `${window.location.origin}/wallet`, // Paystack will append ?trxref=REFERENCE
-      }).unwrap();
-
-      if (result.success && result.data?.authorization_url) {
-        // Redirect to Paystack payment page
-        window.location.href = result.data.authorization_url;
-      }
-    } catch (error: any) {
-      console.error("Fund wallet error:", error);
-      const errorMessage = error?.data?.message || error?.data?.error || "Failed to initialize payment. Please try again.";
-      alert(Array.isArray(errorMessage) ? errorMessage.join(", ") : errorMessage);
-    }
-  };
+  const calculateAPH = (ngnAmount: number) => ngnAmount / 1.25;
+  const calculateAfterFee = (aphAmount: number) => aphAmount * 0.95;
 
   const ngnAmount = parseFloat(fundAmount) || 0;
   const aphEquivalent = calculateAPH(ngnAmount);
   const aphAfterFee = calculateAfterFee(aphEquivalent);
 
+  const handleVerifyPayment = async (reference: string) => {
+    setVerifyError(null);
+    try {
+      const result = await verifyPayment({ reference }).unwrap();
+      if (result.success && result.data) {
+        const credited = result.data.amount ?? 0;
+        const newBalance = result.data.balance;
+
+        setFundedAmount(credited);
+        // Set optimistic balance immediately from the verify response
+        if (typeof newBalance === "number") {
+          setOptimisticBalance(newBalance);
+        }
+        setIsSuccessModalOpen(true);
+        // Force-refetch both — when they return, optimistic balance is cleared
+        refetchBalance().then(() => setOptimisticBalance(null));
+        refetchTransactions();
+        if (typeof window !== "undefined") {
+          window.history.replaceState({}, "", "/wallet");
+        }
+      } else {
+        setVerifyError(
+          (result as any)?.message || "Verification failed. If you were charged, please contact support."
+        );
+      }
+    } catch (err: any) {
+      const msg = err?.data?.message || err?.message || "Payment verification failed. Please contact support.";
+      setVerifyError(Array.isArray(msg) ? msg.join(", ") : msg);
+    }
+  };
+
+  // Handle Paystack callback on page mount
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const urlParams = new URLSearchParams(window.location.search);
+    const reference = urlParams.get("reference") || urlParams.get("trxref");
+    if (reference && !isSuccessModalOpen && !isVerifyingPayment) {
+      handleVerifyPayment(reference);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleFundWallet = async () => {
+    setFundError(null);
+    if (!fundAmount || parseFloat(fundAmount) <= 0) {
+      setFundError("Please enter a valid amount.");
+      return;
+    }
+    if (!user?.email) {
+      setFundError("Your email is required. Please update your profile.");
+      return;
+    }
+    if (aphEquivalent < 100) {
+      setFundError(`Minimum funding is 100 APH (₦${Math.ceil(100 * 1.25).toLocaleString()} NGN).`);
+      return;
+    }
+    try {
+      const result = await fundWallet({
+        amount: aphEquivalent,
+        email: user.email,
+        callbackUrl: `${window.location.origin}/wallet`,
+      }).unwrap();
+      if (result.success && result.data?.authorization_url) {
+        window.location.href = result.data.authorization_url;
+      }
+    } catch (error: any) {
+      const msg = error?.data?.message || error?.message || "Failed to initialize payment.";
+      setFundError(Array.isArray(msg) ? msg.join(", ") : msg);
+    }
+  };
+
+  const handleRequestPayout = async () => {
+    setPayoutError(null);
+    const amount = parseFloat(payoutAmount);
+    if (!amount || amount <= 0) {
+      setPayoutError("Enter a valid payout amount.");
+      return;
+    }
+    if (!selectedAccountId && withdrawalAccounts.length > 0) {
+      setPayoutError("Select a withdrawal account.");
+      return;
+    }
+    if (walletBalance && amount > walletBalance.balance) {
+      setPayoutError("Amount exceeds your wallet balance.");
+      return;
+    }
+    try {
+      const result = await createPayout({
+        amount,
+        accountId: selectedAccountId || undefined,
+      }).unwrap();
+      if (result.success && result.data) {
+        setPayoutSuccess({ amount: result.data.amount, netAmount: result.data.netAmount });
+        setPayoutAmount("");
+        setSelectedAccountId("");
+        refetchBalance();
+        refetchTransactions();
+      }
+    } catch (error: any) {
+      const msg = error?.data?.message || error?.message || "Payout request failed.";
+      setPayoutError(Array.isArray(msg) ? msg.join(", ") : msg);
+    }
+  };
+
   const formatDate = (dateString: string) => {
     const date = new Date(dateString);
-    const days = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
-    const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-    
+    const days = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+    const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
     const day = days[date.getDay()];
     const dayNum = date.getDate();
     const month = months[date.getMonth()];
     const year = date.getFullYear();
-    
     const hours = date.getHours();
     const minutes = date.getMinutes();
-    const ampm = hours >= 12 ? 'pm' : 'am';
+    const ampm = hours >= 12 ? "pm" : "am";
     const displayHours = hours % 12 || 12;
-    const displayMinutes = minutes.toString().padStart(2, '0');
-    
-    return `${day}, ${dayNum}${getOrdinalSuffix(dayNum)} ${month}. ${year} • ${displayHours}:${displayMinutes}${ampm}`;
-  };
-
-  const getOrdinalSuffix = (num: number) => {
-    const j = num % 10;
-    const k = num % 100;
-    if (j === 1 && k !== 11) return 'st';
-    if (j === 2 && k !== 12) return 'nd';
-    if (j === 3 && k !== 13) return 'rd';
-    return 'th';
+    const displayMinutes = minutes.toString().padStart(2, "0");
+    const j = dayNum % 10, k = dayNum % 100;
+    const suffix = j === 1 && k !== 11 ? "st" : j === 2 && k !== 12 ? "nd" : j === 3 && k !== 13 ? "rd" : "th";
+    return `${day}, ${dayNum}${suffix} ${month}. ${year} • ${displayHours}:${displayMinutes}${ampm}`;
   };
 
   const getStatusStyles = (status: string) => {
-    const statusLower = status.toLowerCase();
-    if (statusLower === 'success' || statusLower === 'successful' || statusLower === 'completed') {
-      return {
-        bg: 'bg-[#10B9811A]', // Green background with opacity
-        text: 'text-[#10B981]', // Green text
-      };
-    }
-    if (statusLower === 'pending' || statusLower === 'processing') {
-      return {
-        bg: 'bg-[#FFCFA21A]', // Orange background with opacity
-        text: 'text-[#FF993A]', // Orange text
-      };
-    }
-    if (statusLower === 'failed' || statusLower === 'cancelled') {
-      return {
-        bg: 'bg-[#EF44441A]', // Red background with opacity
-        text: 'text-[#EF4444]', // Red text
-      };
-    }
-    return {
-      bg: 'bg-[#6B72801A]', // Gray background with opacity
-      text: 'text-[#6B7280]', // Gray text
-    };
+    const s = status.toLowerCase();
+    if (s === "success" || s === "successful" || s === "completed") return { bg: "bg-[#10B9811A]", text: "text-[#10B981]" };
+    if (s === "pending" || s === "processing") return { bg: "bg-[#FFCFA21A]", text: "text-[#FF993A]" };
+    if (s === "failed" || s === "cancelled") return { bg: "bg-[#EF44441A]", text: "text-[#EF4444]" };
+    return { bg: "bg-[#6B72801A]", text: "text-[#6B7280]" };
   };
 
   const getStatusText = (status: string) => {
-    const statusLower = status.toLowerCase();
-    if (statusLower === 'success' || statusLower === 'completed') {
-      return 'SUCCESSFUL';
-    }
-    if (statusLower === 'pending' || statusLower === 'processing') {
-      return 'PENDING';
-    }
-    if (statusLower === 'failed') {
-      return 'FAILED';
-    }
+    const s = status.toLowerCase();
+    if (s === "success" || s === "completed") return "SUCCESSFUL";
+    if (s === "pending" || s === "processing") return "PENDING";
+    if (s === "failed") return "FAILED";
     return status.toUpperCase();
   };
 
   return (
     <div className="h-full bg-[#1F1B2C] p-6 sm:p-8 overflow-y-auto font-urbanist">
       <div className="max-w-7xl mx-auto space-y-8">
-        {/* Page Title */}
         <h1 className="text-3xl font-bold text-[#FA266D] font-urbanist">Wallet</h1>
 
-        {/* Wallet Balance Card */}
+        {/* Balance Card */}
         <div className="h-[178px] rounded-[24px] bg-[#FFFFFF0F] backdrop-blur-[68px] p-6 sm:p-8 font-urbanist">
           <div className="flex items-center justify-between mb-6">
             <div className="flex items-center gap-3">
               <h2 className="text-xl font-semibold text-white font-urbanist">Wallet Balance</h2>
               <button
                 type="button"
-                onClick={() => {
-                  console.log("Eye icon clicked, current state:", isBalanceVisible);
-                  setIsBalanceVisible(prev => {
-                    console.log("Toggling from", prev, "to", !prev);
-                    return !prev;
-                  });
-                }}
-                className="text-white/60 hover:text-white transition-colors cursor-pointer z-10 relative"
+                onClick={() => setIsBalanceVisible(prev => !prev)}
+                className="text-white/60 hover:text-white transition-colors cursor-pointer"
                 aria-label={isBalanceVisible ? "Hide balance" : "Show balance"}
               >
                 {isBalanceVisible ? <Eye className="w-5 h-5" /> : <EyeOff className="w-5 h-5" />}
               </button>
             </div>
           </div>
-          
+
           <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-6">
             <div>
-              {isLoadingBalance ? (
+              {isLoadingBalance && !optimisticBalance ? (
                 <div className="text-4xl sm:text-5xl font-bold text-white animate-pulse font-urbanist">Loading...</div>
-              ) : walletBalance ? (
-                <div className="flex items-baseline gap-2 font-urbanist text-white">
-                  {isBalanceVisible ? (
-                    <>
-                      <span className="text-[48px] font-extrabold leading-none tracking-[-0.02em]">
-                        {Number(walletBalance.balance || 0).toLocaleString('en-US', { 
-                          minimumFractionDigits: 0, 
-                          maximumFractionDigits: 0 
-                        })}
-                      </span>
-                      <span className="text-[24px] font-semibold leading-none tracking-[-0.02em]">
-                        {walletBalance.currency || 'APH'}
-                      </span>
-                    </>
-                  ) : (
-                    <>
-                      <span className="text-[48px] font-extrabold leading-none tracking-[-0.02em]">••••••</span>
-                      {/* <span className="text-[24px] font-semibold leading-none tracking-[-0.02em]">•••</span> */}
-                    </>
-                  )}
-                </div>
+              ) : isVerifyingPayment ? (
+                <div className="text-2xl font-semibold text-white/70 animate-pulse font-urbanist">Verifying payment...</div>
               ) : (
                 <div className="flex items-baseline gap-2 font-urbanist text-white">
                   {isBalanceVisible ? (
                     <>
-                      <span className="text-[48px] font-extrabold leading-none tracking-[-0.02em]">0</span>
-                      <span className="text-[24px] font-semibold leading-none tracking-[-0.02em]">APH</span>
+                      <span className="text-[48px] font-extrabold leading-none tracking-[-0.02em]">
+                        {Number(displayBalance).toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}
+                      </span>
+                      <span className="text-[24px] font-semibold leading-none tracking-[-0.02em]">
+                        {walletBalance?.currency || "APH"}
+                      </span>
                     </>
                   ) : (
-                    <>
-                      <span className="text-[48px] font-extrabold leading-none tracking-[-0.02em]">••••••</span>
-                      {/* <span className="text-[24px] font-semibold leading-none tracking-[-0.02em]">•••</span> */}
-                    </>
+                    <span className="text-[48px] font-extrabold leading-none tracking-[-0.02em]">••••••</span>
                   )}
                 </div>
               )}
+              {verifyError && (
+                <p className="text-sm text-red-400 mt-2">{verifyError}</p>
+              )}
             </div>
-            
+
             <div className="flex flex-col sm:flex-row gap-3 w-full sm:w-auto">
-              <button 
-                onClick={() => setIsFundModalOpen(true)}
-                className="w-[183px] h-[56px] rounded-[30px] bg-[#FA266D] hover:bg-pink-600 text-white flex items-center justify-center gap-2 transition-colors font-urbanist font-semibold text-base leading-none capitalize"
+              <button
+                onClick={() => { setIsFundModalOpen(true); setFundError(null); }}
+                className="w-[183px] h-[56px] rounded-[30px] bg-[#FA266D] hover:bg-pink-600 text-white flex items-center justify-center gap-2 transition-colors font-urbanist font-semibold text-base capitalize"
               >
                 <Plus className="w-5 h-5" />
                 <span>Fund Wallet</span>
               </button>
               {(isDiva || isHunk) && (
-                <button className="w-[210px] h-[56px] rounded-[30px] bg-white hover:bg-white/90 text-[#FA266D] flex items-center justify-center gap-2 transition-colors font-urbanist font-semibold text-base leading-none capitalize">
+                <button
+                  onClick={() => { setIsPayoutModalOpen(true); setPayoutError(null); setPayoutSuccess(null); }}
+                  className="w-[210px] h-[56px] rounded-[30px] bg-white hover:bg-white/90 text-[#FA266D] flex items-center justify-center gap-2 transition-colors font-urbanist font-semibold text-base capitalize"
+                >
                   <Download className="w-5 h-5" />
                   <span>Request Payout</span>
                 </button>
@@ -294,12 +287,12 @@ export default function WalletPage() {
         {/* Transaction History */}
         <div className="space-y-4">
           <h2 className="text-[16px] font-medium text-white font-urbanist">Transaction History</h2>
-          
+
           {isLoadingTransactions ? (
             <div className="rounded-[24px] bg-[#FFFFFF0F] backdrop-blur-[68px] p-8 text-center">
-              <div className="animate-pulse">
-                <div className="h-4 bg-white/20 rounded w-1/2 mx-auto mb-2"></div>
-                <div className="h-4 bg-white/20 rounded w-1/3 mx-auto"></div>
+              <div className="animate-pulse space-y-2">
+                <div className="h-4 bg-white/20 rounded w-1/2 mx-auto" />
+                <div className="h-4 bg-white/20 rounded w-1/3 mx-auto" />
               </div>
               <p className="text-white/60 mt-4">Loading transactions...</p>
             </div>
@@ -319,40 +312,25 @@ export default function WalletPage() {
                   className="h-[124px] rounded-[24px] bg-[#FFFFFF0F] backdrop-blur-[68px] p-6"
                 >
                   <div className="flex items-center justify-between gap-4">
-                    {/* Left Side - Icon and Amount */}
                     <div className="flex items-start gap-4 flex-1">
-                      <div className={`w-12 h-12 rounded-full flex items-center justify-center ${
-                        transaction.type === 'credit' 
-                          ? 'bg-green-500/20' 
-                          : 'bg-red-500/20'
-                      }`}>
-                        {transaction.type === 'credit' ? (
+                      <div className={`w-12 h-12 rounded-full flex items-center justify-center ${transaction.type === "credit" ? "bg-green-500/20" : "bg-red-500/20"}`}>
+                        {transaction.type === "credit" ? (
                           <ArrowDownLeft className="w-6 h-6 text-green-500" />
                         ) : (
                           <ArrowUpRight className="w-6 h-6 text-red-500" />
                         )}
                       </div>
-                      
                       <div className="flex-1 min-w-0">
                         <div className="text-[32px] font-bold text-white mb-[8px]">
-                          {Number(transaction.amount || 0).toLocaleString('en-US', { 
-                            minimumFractionDigits: 0, 
-                            maximumFractionDigits: 0 
-                          })} <span className="text-[16px] font-medium text-[#FFFFFF]">APH</span>
+                          {Number(transaction.amount || 0).toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}{" "}
+                          <span className="text-[16px] font-medium text-white">APH</span>
                         </div>
                         <div className="font-urbanist font-medium text-[12px] leading-[20px] text-[#807E7E]">
-                          {transaction.type ? transaction.type.charAt(0).toUpperCase() + transaction.type.slice(1) : 'Transaction'}
-                          {transaction.createdAt && (
-                            <>
-                              {' • '}
-                              {formatDate(transaction.createdAt)}
-                            </>
-                          )}
+                          {transaction.type ? transaction.type.charAt(0).toUpperCase() + transaction.type.slice(1) : "Transaction"}
+                          {transaction.createdAt && <> • {formatDate(transaction.createdAt)}</>}
                         </div>
                       </div>
                     </div>
-
-                    {/* Right Side - Status */}
                     <div className="flex items-center gap-[10px]">
                       <span className={`rounded-[20px] py-[6px] px-3 ${getStatusStyles(transaction.status).bg} ${getStatusStyles(transaction.status).text} font-urbanist font-medium text-[12px] leading-none text-center`}>
                         {getStatusText(transaction.status)}
@@ -369,24 +347,18 @@ export default function WalletPage() {
       {/* Fund Wallet Modal */}
       {isFundModalOpen && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-[#FFFFFF0F] backdrop-blur-[68px] rounded-xl sm:rounded-2xl p-6 sm:p-8 w-full max-w-[621px]">
-            {/* Modal Header */}
+          <div className="bg-[#FFFFFF0F] backdrop-blur-[68px] rounded-2xl p-6 sm:p-8 w-full max-w-[621px]">
             <div className="flex items-center justify-between mb-6">
               <h2 className="text-2xl font-bold text-white">Fund Wallet</h2>
-              <button 
-                onClick={() => {
-                  setIsFundModalOpen(false);
-                  setFundAmount("");
-                }}
+              <button
+                onClick={() => { setIsFundModalOpen(false); setFundAmount(""); setFundError(null); }}
                 className="w-8 h-8 rounded-full bg-white/10 flex items-center justify-center hover:bg-white/20 transition-colors"
               >
                 <X className="w-5 h-5 text-white" />
               </button>
             </div>
 
-            {/* Amount Input */}
             <div className="space-y-6 mb-6">
-              {/* Input Field with Icon and Currency Selector */}
               <div className="relative">
                 <div className="absolute left-4 top-1/2 -translate-y-1/2 z-10">
                   <HandCoins className="w-5 h-5 text-white/60" />
@@ -394,84 +366,74 @@ export default function WalletPage() {
                 <input
                   type="number"
                   value={fundAmount}
-                  onChange={(e) => setFundAmount(e.target.value)}
-                  placeholder="How much do you want to deposit?"
-                  className="w-full max-w-[541px] h-[56px] pl-12 pr-[100px] bg-white/5 border border-[#FFFFFF1A] rounded-[32px] text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-[#FA266D] focus:border-transparent [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                  onChange={(e) => { setFundAmount(e.target.value); setFundError(null); }}
+                  placeholder="Amount to deposit (NGN)"
+                  className="w-full h-[56px] pl-12 pr-[100px] bg-white/5 border border-[#FFFFFF1A] rounded-[32px] text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-[#FA266D] focus:border-transparent [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
                 />
                 <div className="absolute right-4 top-1/2 -translate-y-1/2 flex items-center gap-2 pr-2">
-                  <select
-                    value={currency}
-                    onChange={(e) => setCurrency(e.target.value)}
-                    className="bg-transparent border-none text-white focus:outline-none appearance-none pr-2 cursor-pointer font-urbanist"
-                  >
-                    <option value="NGN" className="bg-[#1F1B2C]">NGN</option>
-                  </select>
-                  <ChevronDown className="w-4 h-4 text-white/60 pointer-events-none" />
+                  <span className="text-white font-urbanist">NGN</span>
+                  <ChevronDown className="w-4 h-4 text-white/60" />
                 </div>
               </div>
 
-              {/* Equivalent Amount and What You Will Get - Side by Side */}
               {ngnAmount > 0 && (
                 <div className="rounded-lg p-4">
                   <div className="flex items-center justify-between gap-4">
                     <div className="flex-1">
                       <div className="text-white/60 text-[16px] font-medium mb-1">Equivalent Amount</div>
                       <div className="text-white font-bold text-[32px]">
-                        {aphEquivalent.toLocaleString('en-US', { 
-                          minimumFractionDigits: 0, 
-                          maximumFractionDigits: 0 
-                        })} <span className="text-[16px] font-medium">APH</span>
+                        {aphEquivalent.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}{" "}
+                        <span className="text-[16px] font-medium">APH</span>
                       </div>
                     </div>
                     <div className="flex-1">
                       <div className="text-white/60 text-[16px] font-medium mb-1">What You Will Get</div>
-                      <div className="text-white  text-[32px] font-bold ">
-                        {aphAfterFee.toLocaleString('en-US', { 
-                          minimumFractionDigits: 0, 
-                          maximumFractionDigits: 0 
-                        })} <span className="text-[16px] font-medium">APH</span>
+                      <div className="text-white text-[32px] font-bold">
+                        {aphAfterFee.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })}{" "}
+                        <span className="text-[16px] font-medium">APH</span>
                       </div>
                     </div>
                   </div>
                 </div>
               )}
 
-              {/* Warning Message */}
               <div className="flex items-start gap-3">
                 <div className="w-6 h-6 rounded-full bg-[#FA266D] flex items-center justify-center flex-shrink-0">
                   <span className="text-white font-bold text-sm">!</span>
                 </div>
                 <p className="font-urbanist font-normal text-base leading-6 tracking-[-0.02em] text-[#FFFFFF99]">
-                  Kindly note that we deduct 5% fee as service charge on all transactions.
+                  Kindly note that we deduct 5% as service charge on all transactions.
                 </p>
               </div>
 
-              {/* Minimum Amount Validation Message */}
               {ngnAmount > 0 && aphEquivalent < 100 && (
                 <div className="flex items-start gap-3 bg-orange-500/10 border border-orange-500/20 rounded-lg p-4">
                   <AlertCircle className="w-5 h-5 text-orange-500 flex-shrink-0 mt-0.5" />
                   <p className="text-sm text-white/80">
-                    Minimum funding amount is 100 APH. Please enter at least ₦{Math.ceil(100 * 1.25).toLocaleString('en-US')} NGN.
+                    Minimum funding amount is 100 APH. Please enter at least ₦{Math.ceil(100 * 1.25).toLocaleString()} NGN.
                   </p>
+                </div>
+              )}
+
+              {fundError && (
+                <div className="flex items-start gap-3 bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                  <AlertCircle className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" />
+                  <p className="text-sm text-red-300">{fundError}</p>
                 </div>
               )}
             </div>
 
-            {/* Action Buttons - Proceed on top, Cancel below */}
             <div className="flex flex-col gap-3">
               <button
                 onClick={handleFundWallet}
                 disabled={!fundAmount || parseFloat(fundAmount) <= 0 || aphEquivalent < 100 || isFundingWallet}
-                className="w-full max-w-[541px] h-[56px] rounded-[30px] bg-[#FA266D] hover:bg-pink-600 text-white font-urbanist font-semibold text-base leading-none capitalize transition-colors disabled:bg-gray-500 disabled:cursor-not-allowed"
+                className="w-full h-[56px] rounded-[30px] bg-[#FA266D] hover:bg-pink-600 text-white font-urbanist font-semibold text-base capitalize transition-colors disabled:bg-gray-500 disabled:cursor-not-allowed"
               >
-                {isFundingWallet ? 'Processing...' : 'Proceed'}
+                {isFundingWallet ? "Processing..." : "Proceed"}
               </button>
               <button
-                onClick={() => {
-                  setIsFundModalOpen(false);
-                  setFundAmount("");
-                }}
-                className="w-full max-w-[541px] h-[56px] rounded-[30px] bg-white hover:bg-white/90 text-[#FA266D] font-urbanist font-semibold text-base leading-none capitalize transition-colors"
+                onClick={() => { setIsFundModalOpen(false); setFundAmount(""); setFundError(null); }}
+                className="w-full h-[56px] rounded-[30px] bg-white hover:bg-white/90 text-[#FA266D] font-urbanist font-semibold text-base capitalize transition-colors"
               >
                 Cancel
               </button>
@@ -480,39 +442,146 @@ export default function WalletPage() {
         </div>
       )}
 
-      {/* Success Modal */}
+      {/* Request Payout Modal */}
+      {isPayoutModalOpen && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-[#FFFFFF0F] backdrop-blur-[68px] rounded-2xl p-6 sm:p-8 w-full max-w-[540px]">
+            <div className="flex items-center justify-between mb-6">
+              <h2 className="text-2xl font-bold text-white">Request Payout</h2>
+              <button
+                onClick={() => { setIsPayoutModalOpen(false); setPayoutError(null); setPayoutSuccess(null); setPayoutAmount(""); }}
+                className="w-8 h-8 rounded-full bg-white/10 flex items-center justify-center hover:bg-white/20 transition-colors"
+              >
+                <X className="w-5 h-5 text-white" />
+              </button>
+            </div>
+
+            {payoutSuccess ? (
+              <div className="text-center space-y-4 py-4">
+                <div className="w-20 h-20 rounded-full bg-green-500/20 flex items-center justify-center mx-auto">
+                  <CheckCircle className="w-10 h-10 text-green-400" />
+                </div>
+                <h3 className="text-xl font-semibold text-white">Payout Requested</h3>
+                <p className="text-white/70 text-sm">
+                  Your payout of <span className="text-white font-semibold">{payoutSuccess.amount.toLocaleString()} APH</span> has been submitted.
+                  You'll receive <span className="text-white font-semibold">{payoutSuccess.netAmount.toLocaleString()} APH</span> after the 5% service fee.
+                </p>
+                <button
+                  onClick={() => { setIsPayoutModalOpen(false); setPayoutSuccess(null); }}
+                  className="w-full h-[52px] rounded-[30px] bg-[#FA266D] hover:bg-pink-600 text-white font-semibold transition-colors"
+                >
+                  Done
+                </button>
+              </div>
+            ) : (
+              <div className="space-y-5">
+                <div className="rounded-[16px] bg-white/5 border border-white/10 p-4">
+                  <p className="text-xs text-white/50 mb-1">Available balance</p>
+                  <p className="text-2xl font-bold text-white">
+                    {Number(walletBalance?.balance ?? 0).toLocaleString("en-US")} <span className="text-base font-medium">APH</span>
+                  </p>
+                </div>
+
+                <div className="relative">
+                  <input
+                    type="number"
+                    value={payoutAmount}
+                    onChange={(e) => { setPayoutAmount(e.target.value); setPayoutError(null); }}
+                    placeholder="Amount to withdraw (APH)"
+                    className="w-full h-[56px] px-5 bg-white/5 border border-[#FFFFFF1A] rounded-[32px] text-white placeholder-white/40 focus:outline-none focus:ring-2 focus:ring-[#FA266D] [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                  />
+                </div>
+
+                {payoutAmount && parseFloat(payoutAmount) > 0 && (
+                  <div className="text-sm text-white/60 px-1">
+                    You'll receive ≈{" "}
+                    <span className="text-white font-semibold">
+                      {(parseFloat(payoutAmount) * 0.95).toLocaleString("en-US", { maximumFractionDigits: 0 })} APH
+                    </span>{" "}
+                    after 5% service fee
+                  </div>
+                )}
+
+                {withdrawalAccounts.length > 0 && (
+                  <select
+                    value={selectedAccountId}
+                    onChange={(e) => setSelectedAccountId(e.target.value)}
+                    className="w-full h-[56px] px-5 bg-white/5 border border-[#FFFFFF1A] rounded-[32px] text-white focus:outline-none focus:ring-2 focus:ring-[#FA266D] appearance-none"
+                  >
+                    <option value="" className="bg-[#1F1B2C]">Select withdrawal account</option>
+                    {withdrawalAccounts.map((acc) => (
+                      <option key={acc._id} value={acc._id} className="bg-[#1F1B2C]">
+                        {acc.bankName} — {acc.accountNumber} ({acc.accountName})
+                      </option>
+                    ))}
+                  </select>
+                )}
+
+                {withdrawalAccounts.length === 0 && (
+                  <div className="flex items-start gap-3 bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-4">
+                    <AlertCircle className="w-5 h-5 text-yellow-400 flex-shrink-0 mt-0.5" />
+                    <p className="text-sm text-yellow-300">
+                      No withdrawal account set up. Please add a bank account in your profile settings before requesting a payout.
+                    </p>
+                  </div>
+                )}
+
+                <div className="flex items-start gap-3">
+                  <div className="w-6 h-6 rounded-full bg-[#FA266D] flex items-center justify-center flex-shrink-0">
+                    <span className="text-white font-bold text-sm">!</span>
+                  </div>
+                  <p className="text-sm leading-6 text-[#FFFFFF99]">
+                    A 5% service fee is deducted from all payouts.
+                  </p>
+                </div>
+
+                {payoutError && (
+                  <div className="flex items-start gap-3 bg-red-500/10 border border-red-500/20 rounded-lg p-4">
+                    <AlertCircle className="w-5 h-5 text-red-400 flex-shrink-0 mt-0.5" />
+                    <p className="text-sm text-red-300">{payoutError}</p>
+                  </div>
+                )}
+
+                <div className="flex flex-col gap-3 pt-1">
+                  <button
+                    onClick={handleRequestPayout}
+                    disabled={isRequestingPayout || !payoutAmount || parseFloat(payoutAmount) <= 0 || withdrawalAccounts.length === 0}
+                    className="w-full h-[56px] rounded-[30px] bg-[#FA266D] hover:bg-pink-600 text-white font-semibold transition-colors disabled:bg-gray-500 disabled:cursor-not-allowed"
+                  >
+                    {isRequestingPayout ? "Processing..." : "Request Payout"}
+                  </button>
+                  <button
+                    onClick={() => { setIsPayoutModalOpen(false); setPayoutError(null); setPayoutAmount(""); }}
+                    className="w-full h-[56px] rounded-[30px] bg-white hover:bg-white/90 text-[#FA266D] font-semibold transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Fund Success Modal */}
       {isSuccessModalOpen && (
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-[#1F1B2C] rounded-xl sm:rounded-2xl p-6 sm:p-8 w-full max-w-md text-center">
-            {/* Success Icon */}
+          <div className="bg-[#1F1B2C] rounded-2xl p-6 sm:p-8 w-full max-w-md text-center">
             <div className="flex justify-center mb-6">
               <div className="w-20 h-20 bg-green-500 rounded-full flex items-center justify-center">
                 <CheckCircle className="w-12 h-12 text-white" />
               </div>
             </div>
-
-            {/* Success Message */}
-            <h2 className="text-2xl font-bold text-white mb-4">Wallet Funding Successful</h2>
+            <h2 className="text-2xl font-bold text-white mb-4">Wallet Funded Successfully</h2>
             <p className="text-white/80 mb-6">
-              Your wallet has been funded successfully with the total amount of{" "}
+              Your wallet has been credited with{" "}
               <span className="font-semibold text-white">
-                {fundedAmount.toLocaleString('en-US', { 
-                  minimumFractionDigits: 0, 
-                  maximumFractionDigits: 0 
-                })}APH
+                {fundedAmount.toLocaleString("en-US", { minimumFractionDigits: 0, maximumFractionDigits: 0 })} APH
               </span>
-              . Now, go ahead and start exploring.
+              . Go ahead and start exploring.
             </p>
-
-            {/* Action Button */}
             <button
-              onClick={() => {
-                setIsSuccessModalOpen(false);
-                setFundedAmount(0);
-                setPaymentReference(null);
-                // Clear URL parameters
-                window.history.replaceState({}, '', '/wallet');
-              }}
+              onClick={() => { setIsSuccessModalOpen(false); setFundedAmount(0); }}
               className="w-full px-6 py-3 bg-[#FA266D] hover:bg-pink-600 text-white rounded-lg font-medium transition-colors"
             >
               Okay, got it

--- a/components/dashboard/Sidebar.tsx
+++ b/components/dashboard/Sidebar.tsx
@@ -20,8 +20,12 @@ import {
   Users,
   Megaphone,
   Lock,
+  Wallet,
 } from "lucide-react";
 import { useRouter, usePathname } from "next/navigation";
+import { useSelector } from "react-redux";
+import { selectUid, selectCurrentUser } from "@/feature/authentication/authSlice";
+import { useGetEnrichedProfileQuery } from "@/feature/profile/profileApiSlice";
 
 interface SidebarProps {
   isOpen: boolean;
@@ -36,6 +40,7 @@ const sidebarItems = [
   { id: "feeds", label: "Feeds", icon: Smile, href: "/feeds" },
   { id: "strip-room", label: "Strip Room", icon: Play, href: "/strip-room" },
   { id: "orders", label: "Orders", icon: ShoppingCart, href: "/orders" },
+  { id: "wallet", label: "Wallet", icon: Wallet, href: "/wallet" },
   { id: "chats", label: "Chats", icon: MessageCircle, href: "/chat" },
   { id: "connections", label: "Connections", icon: Users, href: "/connections" },
   { id: "advertisement", label: "Advertisement", icon: Megaphone, href: "/advertisement" },
@@ -51,6 +56,29 @@ export default function Sidebar({
 }: SidebarProps) {
   const router = useRouter();
   const pathname = usePathname();
+  const uid = useSelector(selectUid);
+  const authUser = useSelector(selectCurrentUser);
+  const isProvider = authUser?.userType === 'diva' || authUser?.userType === 'hunk';
+
+  // Only fetch provider profile for diva/hunk users — clients don't have one
+  const { data: profileData } = useGetEnrichedProfileQuery(uid!, { skip: !uid || !isProvider });
+  const profile = (profileData as any)?.data || (profileData as any);
+
+  // Completion banner only relevant for providers (diva/hunk)
+  const isProfileComplete = !isProvider || !!(
+    profile?.bio &&
+    profile?.occupation &&
+    profile?.education &&
+    profile?.gender &&
+    profile?.ethnicity &&
+    profile?.nationality &&
+    profile?.bodyBuild &&
+    profile?.looks &&
+    Array.isArray(profile?.services) && profile.services.length > 0 &&
+    Array.isArray(profile?.media) && profile.media.length > 0 &&
+    profile?.hasVideoProof &&
+    profile?.issuedIdUrl
+  );
 
   const handleNavigation = (href: string) => {
     router.push(href);
@@ -110,26 +138,28 @@ export default function Sidebar({
           );
         })}
 
-        {/* complete ur profile setup */}
-        <div className="px-3 sm:px-6 pb-4 sm:pb-6">
-          {isOpen && (
-            <div className="mt-6 sm:mt-8 p-3 sm:p-4 bg-white/6 rounded-[20px] sm:rounded-[24px] text-white">
-              <p className="text-base sm:text-[18px] font-bold mb-2">
-                Complete Your Profile Setup Now!
-              </p>
-              <p className="text-xs sm:text-[14px] mb-3 sm:mb-4 text-white/60">
-                Finish setting up your account, add your services and pricing to
-                start getting clients.
-              </p>
-              <button
-                onClick={() => handleNavigation("/profile")}
-                className="w-full flex items-center justify-center px-4 sm:px-[24px] py-2 sm:py-[10px] text-white bg-[#FA266D] rounded-[30px] sm:rounded-[40px] transition-all duration-200 cursor-pointer"
-              >
-                <span className="text-sm sm:text-[16px] font-semibold">Go to Profile</span>
-              </button>
-            </div>
-          )}
-        </div>
+        {/* complete ur profile setup — hidden once all steps are done */}
+        {!isProfileComplete && (
+          <div className="px-3 sm:px-6 pb-4 sm:pb-6">
+            {isOpen && (
+              <div className="mt-6 sm:mt-8 p-3 sm:p-4 bg-white/6 rounded-[20px] sm:rounded-[24px] text-white">
+                <p className="text-base sm:text-[18px] font-bold mb-2">
+                  Complete Your Profile Setup Now!
+                </p>
+                <p className="text-xs sm:text-[14px] mb-3 sm:mb-4 text-white/60">
+                  Finish setting up your account, add your services and pricing to
+                  start getting clients.
+                </p>
+                <button
+                  onClick={() => handleNavigation("/profile")}
+                  className="w-full flex items-center justify-center px-4 sm:px-[24px] py-2 sm:py-[10px] text-white bg-[#FA266D] rounded-[30px] sm:rounded-[40px] transition-all duration-200 cursor-pointer"
+                >
+                  <span className="text-sm sm:text-[16px] font-semibold">Go to Profile</span>
+                </button>
+              </div>
+            )}
+          </div>
+        )}
       </nav>
 
       {/* Sidebar Footer */}

--- a/components/dashboard/messages/CheckoutModal.tsx
+++ b/components/dashboard/messages/CheckoutModal.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Check, MapPin, ChevronDown } from "lucide-react";
+import { Check, MapPin, ChevronDown, AlertTriangle, Plus } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
-import { useCreateOrderMutation, useGetWalletBalanceQuery } from "@/app/api/apiSlice";
+import { useCreateOrderMutation, useGetWalletBalanceQuery, useFundWalletMutation } from "@/app/api/apiSlice";
 import type { CreateOrderPayload } from "@/lib/types";
 import { useEnrichedProfile } from "@/lib/hooks/useEnrichedProfile";
+import { useAuthProfile } from "@/lib/hooks";
 
 type PricingAmounts = { incall: string; outcall: string };
 
@@ -41,6 +42,10 @@ export function CheckoutModal({
   const [driverMessage, setDriverMessage] = useState("");
   const [showSuccess, setShowSuccess] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [showTopUp, setShowTopUp] = useState(false);
+  const [topUpAmount, setTopUpAmount] = useState("");
+  const [topUpError, setTopUpError] = useState<string | null>(null);
+  const { user: authUser } = useAuthProfile();
 
   const { profile: providerProfile } = useEnrichedProfile(providerUserId || null);
 
@@ -76,6 +81,41 @@ export function CheckoutModal({
   }, [walletResp]);
 
   const [createOrder, { isLoading }] = useCreateOrderMutation();
+  const [fundWallet, { isLoading: isFunding }] = useFundWalletMutation();
+
+  const insufficientBalance = total > 0 && walletBalance < total;
+  const shortfall = Math.max(0, total - walletBalance);
+
+  const handleTopUp = async () => {
+    setTopUpError(null);
+    const ngnAmount = parseFloat(topUpAmount);
+    if (!ngnAmount || ngnAmount <= 0) {
+      setTopUpError("Enter a valid amount in NGN.");
+      return;
+    }
+    if (!authUser?.email) {
+      setTopUpError("Your email is required. Please update your profile.");
+      return;
+    }
+    const aphEquivalent = ngnAmount / 1.25;
+    if (aphEquivalent < 100) {
+      setTopUpError(`Minimum top-up is 100 APH (₦${Math.ceil(100 * 1.25).toLocaleString()} NGN).`);
+      return;
+    }
+    try {
+      const result = await fundWallet({
+        amount: aphEquivalent,
+        email: authUser.email,
+        callbackUrl: typeof window !== "undefined" ? `${window.location.origin}/wallet` : undefined,
+      }).unwrap();
+      if (result.success && result.data?.authorization_url) {
+        window.location.href = result.data.authorization_url;
+      }
+    } catch (err: any) {
+      const msg = err?.data?.message || err?.message || "Failed to initialize payment.";
+      setTopUpError(Array.isArray(msg) ? msg.join(", ") : msg);
+    }
+  };
 
   if (!open) return null;
 
@@ -257,26 +297,76 @@ export function CheckoutModal({
 
               <div className="mt-6">
                 <p className="text-base mb-2">Payment Method</p>
-                <div className="flex items-center justify-between border border-white/20 rounded-[20px] p-4">
+                <div className={`flex items-center justify-between border rounded-[20px] p-4 ${insufficientBalance ? "border-red-500/40 bg-red-500/5" : "border-white/20"}`}>
                   <div className="flex items-center gap-3">
                     <div className="w-8 h-8 rounded-full bg-white/10 flex items-center justify-center">₳</div>
                     <div>
                       <p className="text-sm">Wallet</p>
-                      <p className="text-xs text-white/70">
+                      <p className={`text-xs ${insufficientBalance ? "text-red-400" : "text-white/70"}`}>
                         {walletBalance.toLocaleString()} APH
+                        {insufficientBalance && ` · Need ${shortfall.toLocaleString()} more`}
                       </p>
                     </div>
                   </div>
-                  <div className="w-5 h-5 rounded-full border border-white/30" />
+                  <div className={`w-5 h-5 rounded-full border ${insufficientBalance ? "border-red-400" : "border-white/30"}`} />
                 </div>
+
+                {/* Insufficient balance — top-up section */}
+                {insufficientBalance && (
+                  <div className="mt-3 rounded-[16px] border border-yellow-500/20 bg-yellow-500/5 p-4 space-y-3">
+                    <div className="flex items-start gap-2">
+                      <AlertTriangle className="h-4 w-4 text-yellow-400 shrink-0 mt-0.5" />
+                      <p className="text-xs text-yellow-300">
+                        Your balance is {shortfall.toLocaleString()} APH short. Top up your wallet to continue.
+                      </p>
+                    </div>
+                    {!showTopUp ? (
+                      <button
+                        onClick={() => setShowTopUp(true)}
+                        className="flex items-center gap-1.5 text-xs font-semibold text-[#FA266D] hover:text-pink-400 transition-colors"
+                      >
+                        <Plus className="h-3.5 w-3.5" />
+                        Top up wallet
+                      </button>
+                    ) : (
+                      <div className="space-y-2">
+                        <div className="flex gap-2">
+                          <div className="relative flex-1">
+                            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-xs text-white/50">₦</span>
+                            <input
+                              type="number"
+                              placeholder="Amount in NGN"
+                              value={topUpAmount}
+                              onChange={(e) => setTopUpAmount(e.target.value)}
+                              className="w-full pl-7 pr-3 py-2 rounded-[12px] bg-white/10 border border-white/20 text-white text-xs placeholder-white/40 focus:outline-none focus:ring-1 focus:ring-[#FA266D]"
+                            />
+                          </div>
+                          <button
+                            onClick={handleTopUp}
+                            disabled={isFunding}
+                            className="px-4 py-2 rounded-[12px] bg-[#FA266D] text-white text-xs font-semibold hover:bg-pink-600 disabled:bg-gray-600 transition-colors"
+                          >
+                            {isFunding ? "..." : "Fund"}
+                          </button>
+                        </div>
+                        {topUpAmount && parseFloat(topUpAmount) > 0 && (
+                          <p className="text-xs text-white/50">
+                            ≈ {(parseFloat(topUpAmount) / 1.25 * 0.95).toLocaleString("en-US", { maximumFractionDigits: 0 })} APH after 5% fee
+                          </p>
+                        )}
+                        {topUpError && <p className="text-xs text-red-400">{topUpError}</p>}
+                      </div>
+                    )}
+                  </div>
+                )}
               </div>
 
               <button
                 onClick={handlePayNow}
-                disabled={isLoading}
-                className="mt-6 w-full bg-[#FA266D] text-white py-3 px-4 rounded-[20px] text-[18px] font-medium hover:bg-pink-600 disabled:bg-gray-600"
+                disabled={isLoading || insufficientBalance}
+                className="mt-6 w-full bg-[#FA266D] text-white py-3 px-4 rounded-[20px] text-[18px] font-medium hover:bg-pink-600 disabled:bg-gray-600 disabled:cursor-not-allowed"
               >
-                {isLoading ? "Processing..." : "Pay Now"}
+                {isLoading ? "Processing..." : insufficientBalance ? "Insufficient Balance" : "Pay Now"}
               </button>
               {errorMessage && (
                 <p className="mt-3 text-sm text-red-400">{errorMessage}</p>

--- a/components/dashboard/pages/ClientProfilePage.tsx
+++ b/components/dashboard/pages/ClientProfilePage.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { ArrowLeft, Edit } from "lucide-react";
+import { ArrowLeft, Edit, CheckCircle, Circle, AlertTriangle, ChevronRight, ShieldCheck } from "lucide-react";
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useEnrichedProfile } from "@/lib/hooks/useEnrichedProfile";
 import { useAuth } from "@/lib/hooks/useAuth";
 import { ProfilePageSkeleton } from "@/components/ui/Skeleton";
@@ -13,9 +14,19 @@ import { ProfileEditModal } from "@/components/dashboard/profile/ProfileEditModa
 import { ProfileMediaUploadModal } from "@/components/dashboard/profile/ProfileMediaUploadModal";
 
 export default function ClientProfilePage() {
+  const router = useRouter();
   const { user: authUser } = useAuth();
-  const { profile, loading, error, refetch } = useEnrichedProfile(authUser?.id || null);
-  const [activeTab, setActiveTab] = useState<"About" | "Media">("About");
+  const { profile: rawProfile, loading, error, refetch } = useEnrichedProfile(authUser?.id || null);
+
+  // Guard: only use the profile if it actually belongs to this logged-in user.
+  // If the fetched profile's userId doesn't match authUser.id, treat it as null
+  // (can happen when auth state has a stale uid from a previous session).
+  const profile = rawProfile && authUser?.id && rawProfile.userId === authUser.id
+    ? rawProfile
+    : rawProfile && !rawProfile.userId
+      ? rawProfile   // profile exists but userId field absent — allow it
+      : null;
+  const [activeTab, setActiveTab] = useState<"About" | "Media" | "Payment History" | "Verification">("About");
   const [currentMediaIndex, setCurrentMediaIndex] = useState(0);
   const [isEditModalOpen, setIsEditModalOpen] = useState(false);
   const [isMediaModalOpen, setIsMediaModalOpen] = useState(false);
@@ -26,7 +37,6 @@ export default function ClientProfilePage() {
       const interval = setInterval(() => {
         setCurrentMediaIndex(prevIndex => (prevIndex + 1) % mediaLength);
       }, 5000);
-
       return () => clearInterval(interval);
     } else {
       setCurrentMediaIndex(0);
@@ -37,9 +47,7 @@ export default function ClientProfilePage() {
     setCurrentMediaIndex(0);
   }, [profile?.id]);
 
-  if (loading) {
-    return <ProfilePageSkeleton />;
-  }
+  if (loading) return <ProfilePageSkeleton />;
 
   if (error) {
     return (
@@ -47,10 +55,7 @@ export default function ClientProfilePage() {
         <div className="text-center">
           <div className="text-red-400 text-xl mb-4">Error loading profile</div>
           <div className="text-white/80 mb-4">{error}</div>
-          <button
-            onClick={refetch}
-            className="bg-pink-500 hover:bg-pink-600 text-white px-6 py-2 rounded-lg transition-colors cursor-pointer"
-          >
+          <button onClick={refetch} className="bg-pink-500 hover:bg-pink-600 text-white px-6 py-2 rounded-lg transition-colors cursor-pointer">
             Try Again
           </button>
         </div>
@@ -69,10 +74,43 @@ export default function ClientProfilePage() {
   const handlePrimaryActionClick = () => {
     if (activeTab === "Media") {
       setIsMediaModalOpen(true);
-    } else {
+    } else if (activeTab === "About") {
       setIsEditModalOpen(true);
     }
   };
+
+  // Verification steps for client
+  const verificationSteps = [
+    {
+      key: "basic_info",
+      label: "Complete your profile details",
+      description: "Add your bio and basic information so providers know who you are.",
+      done: !!profile?.bio,
+      action: () => setIsEditModalOpen(true),
+      actionLabel: "Edit Profile",
+    },
+    {
+      key: "media",
+      label: "Upload a profile photo",
+      description: "Upload at least one photo to help providers recognise you.",
+      done: Array.isArray(profile?.media) && profile.media.length > 0,
+      action: () => setIsMediaModalOpen(true),
+      actionLabel: "Upload Photo",
+    },
+    {
+      key: "government_id",
+      label: "Upload government ID",
+      description: "A valid government-issued ID (passport, driver's licence, national ID) is required to verify your identity.",
+      done: !!profile?.issuedIdUrl,
+      action: () => router.push("/id-verification"),
+      actionLabel: "Upload ID",
+    },
+  ];
+
+  const completedCount = verificationSteps.filter(s => s.done).length;
+  const total = verificationSteps.length;
+  const allStepsDone = completedCount === total;
+  const percent = Math.round((completedCount / total) * 100);
 
   return (
     <div className="min-h-screen bg-[#1F1B2C]">
@@ -81,16 +119,16 @@ export default function ClientProfilePage() {
           <ArrowLeft className="h-4 w-4 sm:h-5 sm:w-5" />
           <span className="text-sm sm:text-base">Back</span>
         </button>
-        <button
-          onClick={handlePrimaryActionClick}
-          className="hover:bg-pink-600 text-white px-3 sm:px-4 py-2 rounded-full flex items-center gap-1 sm:gap-2 border-[1px] border-white/10 text-sm sm:text-base cursor-pointer"
-        >
-          <Edit className="h-3 w-3 sm:h-4 sm:w-4" />
-          <span className="hidden sm:inline">
-            {activeTab === "Media" ? "Add Media" : "Edit Profile"}
-          </span>
-          <span className="sm:hidden">{activeTab === "Media" ? "Add" : "Edit"}</span>
-        </button>
+        {(activeTab === "About" || activeTab === "Media") && (
+          <button
+            onClick={handlePrimaryActionClick}
+            className="hover:bg-pink-600 text-white px-3 sm:px-4 py-2 rounded-full flex items-center gap-1 sm:gap-2 border-[1px] border-white/10 text-sm sm:text-base cursor-pointer"
+          >
+            <Edit className="h-3 w-3 sm:h-4 sm:w-4" />
+            <span className="hidden sm:inline">{activeTab === "Media" ? "Add Media" : "Edit Profile"}</span>
+            <span className="sm:hidden">{activeTab === "Media" ? "Add" : "Edit"}</span>
+          </button>
+        )}
       </div>
 
       <div className="px-4 sm:px-8 lg:px-12 pb-6">
@@ -104,35 +142,128 @@ export default function ClientProfilePage() {
         </div>
       </div>
 
+      {/* Tabs */}
       <div className="px-4 sm:px-8 lg:px-12 pb-4 sm:pb-6">
         <div className="flex space-x-4 sm:space-x-8 border-b border-white/20 overflow-x-auto scrollbar-hide">
-          <button
-            onClick={() => setActiveTab("About")}
-            className={`pb-3 sm:pb-4 px-1 font-semibold transition-colors text-sm sm:text-base whitespace-nowrap cursor-pointer ${
-              activeTab === "About"
-                ? "text-[#FA266D] border-b-2 border-[#FA266D]"
-                : "text-white/60 hover:text-white"
-            }`}
-          >
-            About
-          </button>
-          <button
-            onClick={() => setActiveTab("Media")}
-            className={`pb-3 sm:pb-4 px-1 font-semibold transition-colors text-sm sm:text-base whitespace-nowrap cursor-pointer ${
-              activeTab === "Media"
-                ? "text-[#FA266D] border-b-2 border-[#FA266D]"
-                : "text-white/60 hover:text-white"
-            }`}
-          >
-            Media
-          </button>
+          {(["About", "Media", "Payment History", "Verification"] as const).map(tab => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`pb-3 sm:pb-4 px-1 font-semibold transition-colors text-sm sm:text-base whitespace-nowrap cursor-pointer ${
+                activeTab === tab
+                  ? "text-[#FA266D] border-b-2 border-[#FA266D]"
+                  : "text-white/60 hover:text-white"
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
         </div>
       </div>
 
-      <div className="px-4 sm:px-8 lg:px-12 pb-4 sm:pb-6">
+      {/* Tab Content */}
+      <div className="px-4 sm:px-8 lg:px-12 pb-8">
         {activeTab === "About" && <ProfileAboutGrid profile={profile} authUser={authUser} />}
 
         {activeTab === "Media" && <ProfileMediaGrid profile={profile} />}
+
+        {activeTab === "Payment History" && (
+          <div className="flex flex-col items-center justify-center py-16 space-y-3">
+            <div className="w-16 h-16 rounded-full bg-white/5 flex items-center justify-center">
+              <svg className="w-8 h-8 text-white/30" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
+              </svg>
+            </div>
+            <p className="text-white/60 text-base">No payment history yet</p>
+            <p className="text-white/30 text-sm">Your transactions will appear here once you make a booking.</p>
+          </div>
+        )}
+
+        {activeTab === "Verification" && (
+          <div className="max-w-2xl space-y-6">
+            {/* Status header */}
+            {profile?.isVerified ? (
+              <div className="flex items-center gap-3 rounded-2xl border border-green-500/20 bg-green-500/5 p-5">
+                <ShieldCheck size={28} className="text-green-400 shrink-0" />
+                <div>
+                  <p className="text-white font-semibold text-[15px]">Your account is verified</p>
+                  <p className="text-[13px] text-white/60 mt-0.5">You have full access to all features on Aphrodite.</p>
+                </div>
+              </div>
+            ) : allStepsDone ? (
+              <div className="flex items-center gap-3 rounded-2xl border border-yellow-500/20 bg-yellow-500/5 p-5">
+                <AlertTriangle size={22} className="text-yellow-400 shrink-0" />
+                <div>
+                  <p className="text-white font-semibold text-[15px]">Pending review</p>
+                  <p className="text-[13px] text-white/60 mt-0.5">
+                    You've completed all steps. Our team will review and verify your account shortly.
+                  </p>
+                </div>
+              </div>
+            ) : (
+              <div className="rounded-2xl border border-yellow-500/20 bg-yellow-500/5 p-5 space-y-3">
+                <div className="flex items-start gap-3">
+                  <AlertTriangle size={20} className="text-yellow-400 shrink-0 mt-0.5" />
+                  <div className="flex-1">
+                    <div className="flex items-center justify-between gap-4 flex-wrap">
+                      <div>
+                        <p className="text-white font-semibold text-[15px]">Complete your profile to get verified</p>
+                        <p className="text-[13px] text-white/60 mt-0.5">
+                          {completedCount} of {total} steps done — once complete, our team will review and verify your account.
+                        </p>
+                      </div>
+                      <span className="text-[13px] font-bold text-yellow-400 shrink-0">{percent}%</span>
+                    </div>
+                    {/* Progress bar */}
+                    <div className="mt-3 h-1.5 w-full rounded-full bg-white/10">
+                      <div
+                        className="h-full rounded-full bg-[#FA266D] transition-all duration-500"
+                        style={{ width: `${percent}%` }}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Steps list */}
+            <div className="space-y-3">
+              {verificationSteps.map(step => (
+                <div
+                  key={step.key}
+                  className={`flex items-center gap-4 rounded-2xl px-5 py-4 ${
+                    step.done
+                      ? "bg-green-500/5 border border-green-500/10"
+                      : "bg-white/5 border border-white/10"
+                  }`}
+                >
+                  {step.done ? (
+                    <CheckCircle size={20} className="text-green-400 shrink-0" />
+                  ) : (
+                    <Circle size={20} className="text-white/30 shrink-0" />
+                  )}
+                  <div className="flex-1 min-w-0">
+                    <p className={`text-[14px] font-semibold ${step.done ? "text-green-400" : "text-white"}`}>
+                      {step.label}
+                    </p>
+                    {!step.done && (
+                      <p className="text-[12px] text-white/50 mt-0.5 leading-snug">{step.description}</p>
+                    )}
+                  </div>
+                  {!step.done && (
+                    <button
+                      onClick={step.action}
+                      className="shrink-0 flex items-center gap-1 text-[13px] font-semibold text-[#FA266D] hover:text-pink-400 transition-colors cursor-pointer"
+                    >
+                      {step.actionLabel}
+                      <ChevronRight size={14} />
+                    </button>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
       </div>
 
       <ProfileEditModal

--- a/components/dashboard/pages/ProfileDetailPage.tsx
+++ b/components/dashboard/pages/ProfileDetailPage.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { ArrowLeft, MapPin, Star, Check, Users, Calendar as CalendarIcon, Heart, BookOpen, MessageCircle, UserPlus, Info, Coins, Play, ThumbsUp, ThumbsDown, ChevronDown, Plus } from "lucide-react";
 import { type Profile } from "@/lib/data/profiles";
-import { useGetProfileByIdQuery } from "@/feature/profile/profileApiSlice";
+import { useGetProfileByIdQuery, useCreateReviewMutation } from "@/feature/profile/profileApiSlice";
 import type { EnrichedProfile } from "@/lib/types/auth.types";
 import { ProfileDetailSkeleton } from "@/components/ui/Skeleton";
 import CustomPricingModal from "../modals/CustomPricingModal";
@@ -50,6 +50,10 @@ export default function ProfileDetailPage() {
     incall: "0",
     outcall: "0",
   });
+  const [reviewSubmitting, setReviewSubmitting] = useState(false);
+  const [reviewError, setReviewError] = useState<string | null>(null);
+  const [reviewSuccess, setReviewSuccess] = useState(false);
+  const [createReview] = useCreateReviewMutation();
 
   // Fetch profile from API
   const { data: profileResponse, isLoading, error } = useGetProfileByIdQuery(profileId, {
@@ -312,9 +316,15 @@ export default function ProfileDetailPage() {
                 <h1 className="text-xl sm:text-2xl lg:text-3xl font-bold text-white">
                   {profile.name}
                 </h1>
-                <div className="w-5 h-5 sm:w-6 sm:h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0">
-                  <Check className="w-3 h-3 sm:w-4 sm:h-4 text-white" />
-                </div>
+                {enrichedProfile?.isVerified ? (
+                  <div className="w-5 h-5 sm:w-6 sm:h-6 bg-green-500 rounded-full flex items-center justify-center flex-shrink-0">
+                    <Check className="w-3 h-3 sm:w-4 sm:h-4 text-white" />
+                  </div>
+                ) : (
+                  <span className="text-[11px] font-medium px-2 py-0.5 rounded-full bg-yellow-500/10 border border-yellow-500/30 text-yellow-400 whitespace-nowrap">
+                    Not verified
+                  </span>
+                )}
               </div>
               <button 
                 onClick={handleLike}
@@ -907,43 +917,36 @@ export default function ProfileDetailPage() {
             ) : (
             <div className="space-y-6">
               {reviews.map((review) => {
-                // Generate initials from userId or use default
-                const reviewId = review.id || review.userId || '';
-                const initials = reviewId 
-                  ? reviewId.slice(0, 2).toUpperCase()
-                  : 'AN';
-                // Generate avatar color based on userId hash
-                const hashColor = reviewId
-                  ? `#${reviewId.slice(-6).padStart(6, '0').replace(/(.{2})/g, '$1')}`
-                  : '#FA266D';
-                const avatarColor = `bg-[${hashColor}]`;
-                
+                // Reviewer display name — use populated fields from backend
+                const displayName: string =
+                  (review as any).reviewerName ||
+                  (review as any).reviewerUserName ||
+                  `User ${(review.reviewerId || '').slice(-4)}` ||
+                  'Anonymous';
+
+                const initials = displayName.slice(0, 2).toUpperCase();
+
                 // Format timestamp
                 const timestamp = review.createdAt
-                  ? new Date(review.createdAt).toLocaleDateString('en-US', { 
-                      month: 'short', 
-                      day: 'numeric', 
-                      year: 'numeric' 
+                  ? new Date(review.createdAt).toLocaleDateString('en-US', {
+                      month: 'short',
+                      day: 'numeric',
+                      year: 'numeric'
                     })
                   : 'Recently';
-                
-                // Get reviewer name from userId or use anonymous
-                const reviewerName = review.userId 
-                  ? `User ${review.userId.slice(-4)}`
-                  : 'Anonymous';
 
                 return (
-                <div key={review.id || reviewId} className="p-6">
+                <div key={review.id || review.reviewerId} className="p-6">
                   <div className="flex items-start gap-4">
                     {/* Avatar */}
-                    <div className={`w-12 h-12 bg-[#FA266D] rounded-full flex items-center justify-center text-white font-semibold text-lg`}>
+                    <div className="w-12 h-12 bg-[#FA266D] rounded-full flex items-center justify-center text-white font-semibold text-lg">
                       {initials}
                     </div>
-                    
+
                     {/* Review Content */}
                     <div className="flex-1 space-y-3">
                       {/* Name */}
-                      <h4 className="text-[#E05090] font-semibold text-lg">{reviewerName}</h4>
+                      <h4 className="text-[#E05090] font-semibold text-lg">{displayName}</h4>
                       
                       {/* Rating and Timestamp */}
                       <div className="flex items-center gap-3">
@@ -1036,16 +1039,45 @@ export default function ProfileDetailPage() {
                 </div>
               </div>
 
+              {/* Feedback */}
+              {reviewError && (
+                <p className="text-red-400 text-sm">{reviewError}</p>
+              )}
+              {reviewSuccess && (
+                <p className="text-green-400 text-sm">Review submitted successfully!</p>
+              )}
+
               {/* Submit Button */}
-              <button 
-                className="text-white font-semibold transition-colors"
+              <button
+                disabled={reviewRating === 0 || reviewSubmitting}
+                onClick={async () => {
+                  if (reviewRating === 0) {
+                    setReviewError("Please select a star rating before submitting.");
+                    return;
+                  }
+                  setReviewError(null);
+                  setReviewSuccess(false);
+                  setReviewSubmitting(true);
+                  try {
+                    await createReview({
+                      profileId,
+                      rating: reviewRating,
+                      comment: reviewText.trim() || undefined,
+                    }).unwrap();
+                    setReviewSuccess(true);
+                    setReviewText("");
+                    setReviewRating(0);
+                  } catch (err: unknown) {
+                    const msg = (err as { data?: { message?: string } })?.data?.message;
+                    setReviewError(msg || "Failed to submit review. Please try again.");
+                  } finally {
+                    setReviewSubmitting(false);
+                  }
+                }}
+                className="text-white font-semibold transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 style={{
                   width: '200px',
                   height: '56px',
-                  top: '1529px',
-                  left: '80px',
-                  opacity: 1,
-                  gap: '10px',
                   borderRadius: '40px',
                   paddingTop: '13px',
                   paddingRight: '24px',
@@ -1054,7 +1086,7 @@ export default function ProfileDetailPage() {
                   backgroundColor: '#FA266D'
                 }}
               >
-                Submit review
+                {reviewSubmitting ? "Submitting…" : "Submit review"}
               </button>
             </div>
           </div>

--- a/lib/types/auth.types.ts
+++ b/lib/types/auth.types.ts
@@ -263,6 +263,10 @@ export interface Pricing {
  */
 export interface ReviewItem {
   id?: string;
+  reviewerId?: string;
+  reviewerName?: string;
+  reviewerUserName?: string;
+  /** @deprecated use reviewerId — kept for backwards compat */
   userId?: string;
   rating?: number;
   comment?: string;
@@ -298,7 +302,11 @@ export interface EnrichedProfile {
   smoker?: boolean;
   looks?: string;
   hasVideoProof?: boolean;
+  videoProofUrl?: string;
+  videoProofFileType?: string;
+  issuedIdUrl?: string;
   issuedIdVerified?: boolean;
+  isVerified?: boolean;
   media?: string[];
   services?: Service[] | string[];
   followersCount?: number;


### PR DESCRIPTION
## Summary
- CheckoutModal: detect insufficient balance and show inline top-up; fix callbackUrl to /wallet so verification runs after payment
- Wallet page: remove all alert() calls, add optimistic balance update from verify response, add full payout modal with account selector and fee preview
- Orders page: add ready_for_pickup to Ongoing tab filter; fix hardcoded date to use selectedOrder.createdAt
- Sidebar: add Wallet link between Orders and Chats

## Test plan
- [ ] CheckoutModal — top-up section shows when balance < order total; redirect returns to /wallet and balance updates
- [ ] Wallet page — Fund Wallet triggers Paystack; balance updates after return; Request Payout opens modal
- [ ] Orders page — ready_for_pickup orders appear in Ongoing tab
- [ ] Sidebar — Wallet link navigates correctly